### PR TITLE
Update flake8 url to GitHub

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     rev: 22.6.0
     hooks:
     -   id: black
--   repo: https://gitlab.com/pycqa/flake8
+-   repo: https://github.com/PyCQA/flake8
     rev: 3.9.2
     hooks:
     -   id: flake8


### PR DESCRIPTION
Since November last year, flake8 repository does not exist in Gitlab ([GitHub Issue](https://github.com/PyCQA/flake8/issues/1737)).
This PR changes the pre-commit URL for flake8 to use the currently maintained repository in GitHub.